### PR TITLE
feat: header(モーダルは未実装)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,8 @@ import { RecoilRoot } from "recoil";
 import "./globals.css";
 import { Inter } from "next/font/google";
 import { Providers } from "./providers";
-import { FooterNav } from "../components/FooterNav";
+import { FooterNav } from "@/components/FooterNav";
+import { Header } from "@/components/Header";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -14,6 +15,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <Providers>
         <html lang="ja">
           <body className={inter.className}>
+            <Header />
             {children}
             <FooterNav />
           </body>

--- a/src/components/Header/LoginModal.tsx
+++ b/src/components/Header/LoginModal.tsx
@@ -1,0 +1,18 @@
+import { useDisclosure } from "@mantine/hooks";
+import { Modal, Group, Button } from "@mantine/core";
+
+export const LoginModal = () => {
+  const [opened, { open, close }] = useDisclosure(false);
+  return (
+    <>
+      <Modal opened={opened} onClose={close} centered>
+        {/* TODO: 中身の実装 */}
+        ログインしてない時のモーダルコンテンツ
+      </Modal>
+
+      <Group position="center">
+        <Button onClick={open}>Login</Button>
+      </Group>
+    </>
+  );
+};

--- a/src/components/Header/SettingsModal.tsx
+++ b/src/components/Header/SettingsModal.tsx
@@ -1,0 +1,22 @@
+import { useDisclosure } from "@mantine/hooks";
+import { Modal, Group } from "@mantine/core";
+import { ActionIcon } from "@mantine/core";
+import { IconSettings } from "@tabler/icons-react";
+
+export const SettingsModal = () => {
+  const [opened, { open, close }] = useDisclosure(false);
+  return (
+    <>
+      <Modal opened={opened} onClose={close} centered>
+        {/* TODO: 中身の実装 */}
+        ログインしてる時のモーダルコンテンツ
+      </Modal>
+
+      <Group position="center">
+        <ActionIcon variant="light" onClick={open}>
+          <IconSettings size="1rem" />
+        </ActionIcon>
+      </Group>
+    </>
+  );
+};

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,0 +1,21 @@
+import { Header as MantineHeader, Group, Box } from "@mantine/core";
+import Image from "next/image";
+import { LoginModal } from "./LoginModal";
+import { SettingsModal } from "./SettingsModal";
+
+export const Header = () => {
+  // TODO: ログインしてるかどうか。後で変える
+  const isLoggedIn = false;
+  return (
+    <Box>
+      <MantineHeader height={60} px="md">
+        <Group position="apart" sx={{ height: "100%" }}>
+          <Image src="/next.svg" alt="Next.js Logo" width={100} height={37} priority />
+
+          {/* TODO: ログインしているかしていないかで条件分岐させる */}
+          {isLoggedIn ? <SettingsModal /> : <LoginModal />}
+        </Group>
+      </MantineHeader>
+    </Box>
+  );
+};


### PR DESCRIPTION
## やったこと
- ヘッダーの大枠を作成
- ヘッダーを全てのページに適用

## 関連Issue
- close #32 

## 備考
- ロゴはあとで変える
- Header内のLoginボタン,設定ボタンのモーダルの中身を大中君に実装してもらう