### PR TITLE
fix: remove NextPageContext dependents

### DIFF
--- a/src/app/management/_functions/redirectLogin.ts
+++ b/src/app/management/_functions/redirectLogin.ts
@@ -1,10 +1,7 @@
-import axios from "axios";
-import { NextPageContext } from "next";
 import { AppRouterInstance } from "next/dist/shared/lib/app-router-context";
-import { redirect } from "next/navigation";
-import { parseCookies } from "nookies";
+// import { parseCookies } from "nookies";
 
-export const redirectLogin = async (router: AppRouterInstance, ctx?: NextPageContext) => {
+export const redirectLogin = async (router: AppRouterInstance) => {
   // const cookie = parseCookies(ctx);
   // console.log(cookie);
   // if (!cookie.login_cookie) {

--- a/src/app/management/layout.tsx
+++ b/src/app/management/layout.tsx
@@ -1,14 +1,12 @@
 "use client";
 import { Header as MantineHeader, Group, Text } from "@mantine/core";
-import { Button, Flex } from "@mantine/core";
-import axios from "axios";
-import { NextPageContext } from "next";
+import { Button } from "@mantine/core";
 import { usePathname, useRouter } from "next/navigation";
 import { destroyCookie, parseCookies } from "nookies";
 import { useEffect, useState } from "react";
 import { managementClient } from "./_aspida/managementAspida";
 
-export default function ManagementLayout({ children }: { children: React.ReactNode }, ctx?: NextPageContext) {
+export default function ManagementLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
   const [logined, setLogined] = useState<{ [key: string]: string }>();
@@ -19,7 +17,7 @@ export default function ManagementLayout({ children }: { children: React.ReactNo
   }, [pathname]);
 
   const logout = async () => {
-    destroyCookie(ctx, "login_cookie");
+    destroyCookie(null, "login_cookie");
     await managementClient.management.logout.post();
     router.push("management/login");
   };

--- a/src/app/management/login/page.tsx
+++ b/src/app/management/login/page.tsx
@@ -1,16 +1,15 @@
 "use client";
 
-import { Card, Image, Text, Button, Group, TextInput, Grid, Container, Flex } from "@mantine/core";
+import { Text, Button, TextInput, Container, Flex } from "@mantine/core";
 import { useForm, zodResolver } from "@mantine/form";
 import { z } from "zod";
 import { setCookie } from "nookies";
 import { useRouter } from "next/navigation";
-import { NextPageContext } from "next";
 import Link from "next/link";
 import { managementClient } from "../_aspida/managementAspida";
 import { LoginAdministratorDto } from "@/@types";
 
-const Login = (ctx: NextPageContext) => {
+const Login = () => {
   const router = useRouter();
 
   const schema = z.object({
@@ -31,7 +30,7 @@ const Login = (ctx: NextPageContext) => {
       await managementClient.management.login.$post({
         body: value,
       });
-      setCookie(ctx, "login_cookie", "logging in", {
+      setCookie(null, "login_cookie", "logging in", {
         maxAge: 30 * 24 * 60 * 60,
       });
       router.push("management/");

--- a/src/app/management/page.tsx
+++ b/src/app/management/page.tsx
@@ -1,14 +1,11 @@
 "use client";
 
 import { Button, Container, Flex, Text } from "@mantine/core";
-import { NextPageContext } from "next";
 import Link from "next/link";
-import { redirectLogin } from "./_functions/redirectLogin";
-import { useRouter } from "next/navigation";
+// import { redirectLogin } from "./_functions/redirectLogin";
 
-const Management = (ctx?: NextPageContext) => {
-  const router = useRouter();
-  redirectLogin(router, ctx);
+const Management = () => {
+  // redirectLogin();
 
   return (
     <Container size={"sm"}>


### PR DESCRIPTION
## やったこと
-  App Routerでは `NextPageContext` が使えないため、依存している箇所を削除・修正

## 関連Issue
- close #133

## 備考
