### PR TITLE
feat: TravelPlanSpotの並べ替え (追加するときの`sortIndex`修正を含む)

### DIFF
--- a/src/app/travelplan/[id]/_components/TimelineWrapper/SelectTourismSpot.tsx
+++ b/src/app/travelplan/[id]/_components/TimelineWrapper/SelectTourismSpot.tsx
@@ -1,23 +1,25 @@
-import React from "react";
+import React, { ComponentPropsWithoutRef, useMemo, useState } from "react";
 import { forwardRef } from "react";
 import { Group, Avatar, Text, Select, Image, Skeleton } from "@mantine/core";
 import { formatTourismForSelector } from "../../utils/formatTourismForSelector";
-import { useRecoilState } from "recoil";
-import { travelPlanTourismSpotInputState } from "@/atoms";
 import { useOfficialSpotList } from "@/hooks/useOfficialSpotList";
 import { useTourismspotBookmarkList } from "@/hooks/useTourismspotBookmarkList";
-import { officialSpotBookmarkList } from "@/mock/mockdata";
 
-type ItemProps = {
-  image: string;
+export type SelectDataItem = {
+  value: string;
   label: string;
-  comment: string;
+  group: string;
+  image: string;
 };
 
-const SelectItem = forwardRef<HTMLDivElement, ItemProps>(function SelectItemBase(
-  { image, label, comment, ...others }: ItemProps,
-  ref
-) {
+export type SelectTourismSpotProps = {
+  onChange: (tourismSpotId: string | undefined) => void;
+};
+
+type SelectItemComponentProps = ComponentPropsWithoutRef<"div"> & SelectDataItem;
+
+const SelectItemComponent = forwardRef<HTMLDivElement, SelectItemComponentProps>((props, ref) => {
+  const { value, label, image, group, ...others } = props;
   return (
     <div ref={ref} {...others}>
       <Group noWrap>
@@ -25,71 +27,63 @@ const SelectItem = forwardRef<HTMLDivElement, ItemProps>(function SelectItemBase
 
         <div>
           <Text size="sm">{label}</Text>
-          <Text size="xs" opacity={0.65}>
-            {comment}
-          </Text>
         </div>
       </Group>
     </div>
   );
 });
+SelectItemComponent.displayName = "SelectItemComponent";
 
-export const SelectTourismSpot = () => {
-  const [travelPlanTourismSpotInput, setTravelPlanTourismSpotInput] = useRecoilState(travelPlanTourismSpotInputState);
+type TourismSpot = {
+  id: string;
+  label: string;
+  group: string;
+  image: string;
+};
+
+export const SelectTourismSpot = (props: SelectTourismSpotProps) => {
+  const { onChange } = props;
+  const [selectedSpot, setSelectedSpot] = useState<TourismSpot | undefined>();
 
   const { data: officialSpotList } = useOfficialSpotList();
   const { data: tourismspotBookmarkList } = useTourismspotBookmarkList();
 
-  const formatData =
+  const formatData: TourismSpot[] | undefined =
     officialSpotList && tourismspotBookmarkList
       ? formatTourismForSelector(officialSpotList, tourismspotBookmarkList)
       : undefined;
 
-  const handleOnChange = (selectedId: string) => {
-    const selectedSpot = formatData?.find((item) => item.id === selectedId);
-    if (selectedSpot) {
-      setTravelPlanTourismSpotInput({
-        ...travelPlanTourismSpotInput,
-        id: selectedSpot.id,
-        image: selectedSpot.image,
-        label: selectedSpot.label,
-      });
-    } else {
-      setTravelPlanTourismSpotInput({
-        ...travelPlanTourismSpotInput,
-        id: "",
-        image: "",
-        label: "",
-      });
-    }
+  const selectData: SelectDataItem[] | undefined = useMemo(
+    () => formatData?.map(({ id, image, label, group }): SelectDataItem => ({ value: id, label, image, group })),
+    [formatData]
+  );
+
+  const handleChange = (value: string | null) => {
+    const spot = formatData?.find((item) => item.id === value);
+    setSelectedSpot(spot);
+    onChange(spot?.id);
   };
 
   return (
     <>
-      {travelPlanTourismSpotInput.image ? (
-        <Image src={travelPlanTourismSpotInput.image} alt="観光地画像" width={200} height={150} fit="cover" />
+      {selectedSpot ? (
+        <Image src={selectedSpot.image} alt="観光地画像" width={200} height={150} fit="cover" />
       ) : (
         <Skeleton animate={false} width={200} height={150} />
       )}
 
-      {formatData && (
+      {selectData && (
         <Select
           label="観光地を選択"
           placeholder="選択してください"
-          itemComponent={SelectItem}
+          itemComponent={SelectItemComponent}
           searchable
-          data={formatData.map(({ image, label, id, group }) => {
-            return {
-              image: image,
-              label: label,
-              value: id,
-              group: group,
-            };
-          })}
+          data={selectData}
           maxDropdownHeight={160}
           nothingFound="見つかりませんでした"
+          filter={(value: string, item: SelectDataItem) => new RegExp(value.trim(), "i").test(item.label)}
           style={{ width: " 95%" }}
-          onChange={handleOnChange}
+          onChange={handleChange}
         />
       )}
     </>

--- a/src/app/travelplan/[id]/_components/TimelineWrapper/SortableItem.tsx
+++ b/src/app/travelplan/[id]/_components/TimelineWrapper/SortableItem.tsx
@@ -1,23 +1,24 @@
-import React from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { Card, Image, Modal, Text, Stack, createStyles, rem } from "@mantine/core";
+import { Card, Image, Text, Stack, createStyles, rem, Selectors, DefaultProps } from "@mantine/core";
 // import { useDisclosure } from "@mantine/hooks";
 import { IconGripVertical } from "@tabler/icons-react";
 import { TravelPlanSpot } from "@/@types";
 
-type Props = {
+// Mantineや内部のコンポーネントと関係しない、純粋なProps
+export type SortableItemNativeProps = {
   item: TravelPlanSpot;
 };
-const useStyles = createStyles((theme) => ({
-  item: {
+
+export type SortableItemStylesParams = {};
+
+const useStyles = createStyles((theme, {}: SortableItemStylesParams) => ({
+  root: {
     display: "flex",
     borderRadius: theme.radius.md,
     border: `${rem(1)} solid ${theme.colorScheme === "dark" ? theme.colors.dark[5] : theme.colors.gray[2]}`,
     padding: `${theme.spacing.sm} ${theme.spacing.xl}`,
-    marginTop: "1rem",
     backgroundColor: theme.colorScheme === "dark" ? theme.colors.dark[5] : theme.white,
-    marginBottom: theme.spacing.sm,
   },
 
   dragHandle: {
@@ -29,28 +30,34 @@ const useStyles = createStyles((theme) => ({
   },
 }));
 
-export const SortableItem = (props: Props) => {
-  const { item } = props;
-  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: item.travelPlanSpotId });
-  const { classes, cx } = useStyles();
+export type SortableItemStylesNames = Selectors<typeof useStyles>;
+export type SortableItemProps = DefaultProps<SortableItemStylesNames, SortableItemStylesParams> &
+  SortableItemNativeProps;
+
+export const SortableItem = (props: SortableItemProps) => {
+  const { item, className, classNames, styles, unstyled } = props;
+  const { classes, cx } = useStyles({}, { name: "SortableItem", classNames, styles, unstyled });
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({
+    id: item.travelPlanSpotId,
+  });
 
   // Modal用
   // const [opened, { open, close }] = useDisclosure(false);
 
-  const style = {
+  const draggableRootStyle = {
+    opacity: isDragging ? 0.4 : undefined,
     transform: CSS.Transform.toString(transform),
     transition,
   };
 
+  // TODO: カードを押したら、モーダルが開いて編集できるようにする
   return (
     <>
-      {/* TODO: カードを押したら、モーダルが開いて編集できるようにする
-      <Modal opened={opened} onClose={close} title="旅のしおりを共有する" centered>
+      {/* <Modal opened={opened} onClose={close} title="旅のしおりを共有する" centered>
         コンテンツ
       </Modal> */}
-
-      <Card ref={setNodeRef} style={style} {...attributes} {...listeners} className={cx(classes.item)}>
-        <div className={classes.dragHandle}>
+      <Card className={cx(className, classes.root)} style={draggableRootStyle} ref={setNodeRef}>
+        <div className={classes.dragHandle} {...attributes} {...listeners} ref={setActivatorNodeRef}>
           <IconGripVertical size="1.05rem" stroke={1.5} />
         </div>
 

--- a/src/app/travelplan/[id]/_components/TimelineWrapper/TimelineWrapper.tsx
+++ b/src/app/travelplan/[id]/_components/TimelineWrapper/TimelineWrapper.tsx
@@ -1,14 +1,8 @@
 "use client";
-import { useEffect, useState } from "react";
 import { RefObject } from "react";
-import { useRecoilState, useRecoilValue } from "recoil";
-import { travelPlanTourismSpotListState, travelPlanTourismSpotInputState, firebaseTokenState } from "@/atoms";
-import { Divider, Box, Button, Modal, Textarea, Flex } from "@mantine/core";
-import { useDisclosure } from "@mantine/hooks";
-import { IconFlag3, IconPlus } from "@tabler/icons-react";
+import { Divider, Box, Flex } from "@mantine/core";
+import { IconFlag3 } from "@tabler/icons-react";
 import { TimelineEditor } from "./TimelineEditor";
-import { SelectTourismSpot } from "./SelectTourismSpot";
-import { createTravelPlanSpot } from "@/utils/createTravelPlanSpot";
 
 type Props = {
   ref: RefObject<HTMLDivElement>;
@@ -17,8 +11,6 @@ type Props = {
 
 export const TimelineWrapper = (props: Props) => {
   const { ref, travelPlanId } = props;
-
-  const token = useRecoilValue(firebaseTokenState);
 
   return (
     <Flex ref={ref} direction="column">

--- a/src/app/travelplan/[id]/_components/TimelineWrapper/TravelPlanSpotModal.tsx
+++ b/src/app/travelplan/[id]/_components/TimelineWrapper/TravelPlanSpotModal.tsx
@@ -1,9 +1,8 @@
 import { Button, Flex, Modal, Textarea } from "@mantine/core";
 import { SelectTourismSpot } from "./SelectTourismSpot";
 import { createTravelPlanSpot } from "@/utils/createTravelPlanSpot";
-import { useState } from "react";
-import { useRecoilState } from "recoil";
-import { travelPlanTourismSpotInputState, travelPlanTourismSpotListState } from "@/atoms";
+import { useCallback, useState } from "react";
+import { useTravelPlan } from "@/hooks/useTravelPlan";
 
 type Props = {
   travelPlanId: string;
@@ -12,29 +11,32 @@ type Props = {
 };
 
 export const TravelPlanSpotModal = ({ travelPlanId, opened, close }: Props) => {
+  const [selectedTourismSpotId, setSelectedTourismSpotId] = useState<string | undefined>();
   const [comment, setComment] = useState<string>("");
-  const [travelPlanTourismSpotList, setTravelPlanTourismSpotList] = useRecoilState(travelPlanTourismSpotListState);
-  const [travelPlanTourismSpotInput, setTravelPlanTourismSpotInput] = useRecoilState(travelPlanTourismSpotInputState);
+  const sortIndexForNewSpot = useSortIndexForNewSpot(travelPlanId);
+  const addButtonDisabled = selectedTourismSpotId == null || sortIndexForNewSpot == null;
 
-  const handleTourismSpotCount = async () => {
-    await createTravelPlanSpot(travelPlanId!, travelPlanTourismSpotInput.id, {
-      tourismSpotId: travelPlanTourismSpotInput.id,
-      comment: comment,
-      sortIndex: travelPlanTourismSpotList.length + 1,
+  const handleSelectTourismSpotChange = useCallback((tourismSpotId?: string) => {
+    setSelectedTourismSpotId(tourismSpotId);
+  }, []);
+
+  const handleAddButtonClick = useCallback(async () => {
+    if (addButtonDisabled) return;
+
+    await createTravelPlanSpot(travelPlanId, selectedTourismSpotId, {
+      tourismSpotId: selectedTourismSpotId,
+      comment,
+      sortIndex: sortIndexForNewSpot,
       minuteSincePrevious: 5,
     });
-    // setTravelPlanTourismSpotList([...travelPlanTourismSpotList, travelPlanSpot]);
-    setTravelPlanTourismSpotInput({
-      id: "",
-      image: "",
-      label: "",
-    });
+
     close();
-  };
+  }, [addButtonDisabled, close, comment, sortIndexForNewSpot, selectedTourismSpotId, travelPlanId]);
+
   return (
     <Modal opened={opened} onClose={close} title="地点を追加する" centered size="lg">
       <Flex mih={50} gap="md" justify="center" align="center" direction="column">
-        <SelectTourismSpot />
+        <SelectTourismSpot onChange={handleSelectTourismSpotChange} />
         <Textarea
           value={comment}
           onChange={(e) => setComment(e.currentTarget.value)}
@@ -45,15 +47,18 @@ export const TravelPlanSpotModal = ({ travelPlanId, opened, close }: Props) => {
           minRows={3}
         />
 
-        <Button
-          variant="light"
-          onClick={handleTourismSpotCount}
-          color="cyan"
-          disabled={!travelPlanTourismSpotInput.id || !comment}
-        >
+        <Button variant="light" onClick={handleAddButtonClick} color="cyan" disabled={addButtonDisabled}>
           プランを追加
         </Button>
       </Flex>
     </Modal>
   );
+};
+
+const useSortIndexForNewSpot = (travelPlanId: string): number | undefined => {
+  const travelPlan = useTravelPlan(travelPlanId);
+  if (travelPlan == null) return;
+
+  const maxSortIndex = travelPlan.travelPlanSpots.reduce((prev, curr) => Math.max(prev, curr.sortIndex), 0);
+  return maxSortIndex + 1;
 };

--- a/src/app/travelplan/[id]/page.tsx
+++ b/src/app/travelplan/[id]/page.tsx
@@ -166,7 +166,7 @@ const Page = () => {
       </Flex>
       <TimelineWrapper ref={imageRef} travelPlanId={travelPlanId} />
 
-      <Button onClick={tourismSpotOpen} color="cyan" variant="light" leftIcon={<IconPlus />}>
+      <Button onClick={tourismSpotOpen} color="cyan" variant="light" leftIcon={<IconPlus />} mt="xs">
         プランを追加
       </Button>
       <TravelPlanSpotModal travelPlanId={travelPlanId} opened={openedTourismSpot} close={tourismSpotClose} />

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -11,28 +11,6 @@ export const travelPlanTourismSpotListState = atom<TravelPlanSpot[]>({
   effects: [],
 });
 
-export const travelPlanTourismSpotCountState = atom({
-  key: "totalTourismSpotCountState",
-  default: 0,
-  effects: [],
-});
-
-type TravelPlanTourismSpotInput = {
-  id: string;
-  image: string;
-  label: string;
-};
-
-export const travelPlanTourismSpotInputState = atom<TravelPlanTourismSpotInput>({
-  key: "travelPlanTourismSpotInputState",
-  default: {
-    id: "",
-    image: "",
-    label: "",
-  },
-  effects: [],
-});
-
 export const firebaseUserIdState = atom<string | undefined>({
   key: "firebaseUserIdState",
   default: undefined,

--- a/src/hooks/useUpdateSortIndex.ts
+++ b/src/hooks/useUpdateSortIndex.ts
@@ -1,0 +1,46 @@
+import { travelPlanState } from "@/atoms";
+import { client } from "@/lib/aspida";
+import { TravelPlan, TravelPlanSpot } from "@/utils/subscribeRemoteTravelPlan";
+import { useRecoilCallback } from "recoil";
+
+export const useUpdateSortIndex = () =>
+  useRecoilCallback(
+    ({ snapshot, set }) =>
+      // このHookが返す関数のシグネチャー (引数と戻り値)
+      (travelPlanId: string, travelPlanSpotId: string, sortIndex: number): void => {
+        // Recoilのstateやバックエンドのエンドポイントは現状、TravelPlan全体を読み書きする必要がある
+        const recoilValue = travelPlanState(travelPlanId);
+        const travelPlan = snapshot.getLoadable(recoilValue).getValue();
+        if (travelPlan == null) return;
+
+        // sortIndexを更新するTravelPlanSpotをtargetSpotとして、要素番号と値を取得する
+        const spots = travelPlan.travelPlanSpots;
+        const targetSpotArrayIndex = spots.findIndex((spot) => spot.travelPlanSpotId === travelPlanSpotId);
+        const targetSpot = spots[targetSpotArrayIndex];
+
+        // 既存の配列やオブジェクトを破壊しないよう、シャローコピーして更新部分を上書き・再ソート
+        const spotsNext: TravelPlanSpot[] = [...spots];
+        spotsNext[targetSpotArrayIndex] = { ...targetSpot, sortIndex };
+        spotsNext.sort((a, b) => a.sortIndex - b.sortIndex);
+        const travelPlanNext: TravelPlan = { ...travelPlan, travelPlanSpots: spotsNext };
+
+        // Recoilへ書き込んで画面に反映させる
+        set(recoilValue, travelPlanNext);
+
+        // サーバーにも同じ内容を送信する
+        // 失敗した際の挙動をまだ規定していないことから、エラーハンドリングは行っていない
+        client.user.travel_plan
+          ._travel_plan_id(travelPlanId)
+          .spot._travel_plan_spot_id(travelPlanSpotId)
+          .$put({
+            body: {
+              id: travelPlanSpotId,
+              tourismSpotId: targetSpot.tourismSpotId,
+              comment: targetSpot.comment,
+              minuteSincePrevious: targetSpot.minuteSincePrevious,
+              sortIndex,
+            },
+          });
+      },
+    []
+  );

--- a/src/utils/subscribeRemoteTravelPlan.ts
+++ b/src/utils/subscribeRemoteTravelPlan.ts
@@ -173,9 +173,8 @@ export const subscribeRemoteTravelPlan = (
 
   // サーバーからTravelPlanUpdateEventを受信し、ローカルのTravelPlanに同じ操作を反映させる
   const processEvent = () => {
-    const eventSource = new EventSource(
-      `${process.env.NEXT_PUBLIC_API_URL}/user/travel_plan/${travelPlanId}/subscribe_update`
-    );
+    const endpointUrl = new URL(`/user/travel_plan/${travelPlanId}/subscribe_update`, process.env.NEXT_PUBLIC_API_URL);
+    const eventSource = new EventSource(endpointUrl.href);
 
     const cancelEventSource = () => {
       eventSource.close();


### PR DESCRIPTION
## やったこと
- TravelPlanSpotをTravelPlanに追加するとき、追加された項目が正しく末尾に配置されるよう`sortIndex`を修正
- 画面のTravelPlanSpot (プラン) 左側の取っ手アイコンをドラッグすることで並び替えできる機能
- 並び替えた結果をサーバーに送信する処理も実装し、複数のブラウザーで同期できることを確認

## 関連Issue
- close #128

## 備考
未ログイン時に「プランを追加」ボタンのモーダルを開くとTourismSpotを選択できない事象を確認したので、別Issueを作成する予定。