### PR TITLE
fix: unexpected scrolling when reorder TravelPlanSpot on mobile

### DIFF
--- a/src/app/travelplan/[id]/_components/TimelineWrapper/SortableItem.tsx
+++ b/src/app/travelplan/[id]/_components/TimelineWrapper/SortableItem.tsx
@@ -19,6 +19,7 @@ const useStyles = createStyles((theme, {}: SortableItemStylesParams) => ({
     border: `${rem(1)} solid ${theme.colorScheme === "dark" ? theme.colors.dark[5] : theme.colors.gray[2]}`,
     padding: `${theme.spacing.sm} ${theme.spacing.xl}`,
     backgroundColor: theme.colorScheme === "dark" ? theme.colors.dark[5] : theme.white,
+    touchAction: "none",
   },
 
   dragHandle: {


### PR DESCRIPTION
## やったこと
- `SortableItem`コンポーネントのstyleに`touch-action: none;`を追加し、ドラッグ時のスクロールを抑制

## 関連Issue
- close #155

## 備考
