### PR TITLE
fix: input value won't be reset when add TravelPlanSpot

### DIFF
--- a/src/app/travelplan/[id]/_components/TimelineWrapper/TravelPlanSpotModal.tsx
+++ b/src/app/travelplan/[id]/_components/TimelineWrapper/TravelPlanSpotModal.tsx
@@ -30,6 +30,8 @@ export const TravelPlanSpotModal = ({ travelPlanId, opened, close }: Props) => {
       minuteSincePrevious: 5,
     });
 
+    setSelectedTourismSpotId(undefined);
+    setComment("");
     close();
   }, [addButtonDisabled, close, comment, sortIndexForNewSpot, selectedTourismSpotId, travelPlanId]);
 


### PR DESCRIPTION
## やったこと
- TravelPlanSpot追加後に`setSelectedTourismSpotId(undefined)`、`setComment("")`を呼び出し、入力内容を初期化するように修正

## 関連Issue
- close #163

## 備考
